### PR TITLE
Define default width for diff gutter

### DIFF
--- a/gitlight.css
+++ b/gitlight.css
@@ -84,6 +84,10 @@ textarea {
 
 /* gitlight: diff */
 
+.gitlight-gutter {
+  width: 32px;
+}
+
 .gitlight-diff {
   overflow: scroll;
 }


### PR DESCRIPTION
If another plugin adds / removes a gutter, the width information specified for the gutter container is lost, meaning that other plugins that use gutters all collapse over one another until they are reapplied.
This fixes that issue by defining a default gutter width which is always available.

Similar fixes have been applied in RuboCop and GBlame.
